### PR TITLE
Refactor wav_read() in audio_processing.py

### DIFF
--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -19,13 +19,12 @@ from sqlalchemy.dialects import postgresql
 
 # File input (single WAV file -> sound file data)
 
-def wav_read(filename, base_dir=None):
+def wav_read(filepath, base_dir='/env/'):
     """Return 1D NumPy array of wave-formatted audio data denoted by filename.
 
     Input should be a string containing the path to a wave-formatted audio file.
     File should be uncompressed 16-bit."""
-    base_dir = base_dir or '/env/'
-    sample_rate, data_2d = wav.read(base_dir + filename)
+    sample_rate, data_2d = wav.read(base_dir + filepath)
     data_1d = [val for val, _ in data_2d]
     return np.array(data_1d)
 
@@ -111,9 +110,9 @@ def extract_keystrokes(sound_data, sample_rate=44100):
 
 # Display extracted keystrokes (WAV file -> all keystroke graphs)
 
-def visualize_keystrokes(filename, base_dir=None):
-    """Display each keystroke contained in WAV file specified by filename."""
-    wav_data = wav_read(filename, base_dir)
+def visualize_keystrokes(filepath, base_dir='/env/'):
+    """Display each keystroke contained in WAV file specified by filepath."""
+    wav_data = wav_read(filepath, base_dir)
     keystrokes = extract_keystrokes(wav_data)
     n = len(keystrokes)
     print(f'Number of keystrokes detected in "{filename}": {n}')
@@ -130,7 +129,7 @@ def visualize_keystrokes(filename, base_dir=None):
 
 # Data collection (multiple WAV files -> ALL keystroke data)
 
-def collect_keystroke_data(base_dir='datasets/keystrokes/',
+def collect_keystroke_data(filepath_base='datasets/keystrokes/',
                            keys=None,
                            output=False,
                            ignore=None):
@@ -153,12 +152,12 @@ def collect_keystroke_data(base_dir='datasets/keystrokes/',
 
     collection = []
     for key in keys:
-        wav_dir = base_dir + key + '/'
-        if output: print(f'> Reading files from {wav_dir} for key "{key}"')
-        for file in os.listdir(wav_dir):
+        filepath = filepath_base + key + '/'
+        if output: print(f'> Reading files from {filepath} for key "{key}"')
+        for file in os.listdir(filepath):
             if output:
                 print(f'  > Extracting keystrokes from "{file}"', end='')
-            wav_data = wav_read(wav_dir + file)
+            wav_data = wav_read(filepath + file)
             keystrokes = extract_keystrokes(wav_data)
             collected = 0
             for i in range(len(keystrokes)):
@@ -197,7 +196,7 @@ class Keystroke(Base):
         return f'<Keystroke(key={self.key_type}, digest={self.sound_digest})>'
 
 
-def connect_to_database(url=os.environ['DATABASE_URL']):
+def connect_to_database(url=os.environ['TEST_DATABASE_URL']):
     """Connect to database and return engine, connection, metadata."""
     engine = db.create_engine(url)
     connection = engine.connect()

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -19,12 +19,12 @@ from sqlalchemy.dialects import postgresql
 
 # File input (single WAV file -> sound file data)
 
-def wav_read(filepath, base_dir='/env/'):
+def wav_read(filepath):
     """Return 1D NumPy array of wave-formatted audio data denoted by filename.
 
     Input should be a string containing the path to a wave-formatted audio file.
     File should be uncompressed 16-bit."""
-    sample_rate, data_2d = wav.read(base_dir + filepath)
+    sample_rate, data_2d = wav.read(filepath)
     data_1d = [val for val, _ in data_2d]
     return np.array(data_1d)
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -9,13 +9,10 @@ import numpy.random as rand
 
 from dataman.audio_processing import *
 
-BASE_DIR = './' # Assumes pytest is called from project base dir
-
 
 def test_wav_read():
     """Assert ouput is a 1D NumPy array of integers."""
-    dummy_file = 'datasets/samples/dummy-recording.wav'
-    result = wav_read(dummy_file, base_dir=BASE_DIR)
+    result = wav_read('datasets/samples/dummy-recording.wav')
     assert type(result) == np.ndarray
     assert result.ndim == 1
     assert type(result[0]) == np.int16
@@ -24,8 +21,7 @@ def test_wav_read():
 class TestSilenceThreshold:
     def test_not_enough_silence(self):
         """Raise exception when a sound contains no initial silence."""
-        input = wav_read('datasets/samples/no-initial-silence.wav',
-                         base_dir=BASE_DIR)
+        input = wav_read('datasets/samples/no-initial-silence.wav')
         with pytest.raises(Exception):
             silence_threshold(input)
 
@@ -64,8 +60,8 @@ class TestExtractKeystrokes:
             'this_is_not_a_password',
         }
         for phrase in phrases:
-            filename = 'datasets/extraction-tests/' + phrase + '.wav'
-            input = wav_read(filename, base_dir=BASE_DIR)
+            filepath = 'datasets/extraction-tests/' + phrase + '.wav'
+            input = wav_read(filepath)
             output = extract_keystrokes(input)
             assert len(output) == len(phrase)
 
@@ -76,21 +72,21 @@ class TestExtractKeystrokes:
             'how_many_keystrokes_was_that_',
         }
         for phrase in phrases:
-            filename = 'datasets/extraction-tests/' + phrase + '.wav'
-            input = wav_read(filename, base_dir=BASE_DIR)
+            filepath = 'datasets/extraction-tests/' + phrase + '.wav'
+            input = wav_read(filepath)
             output = extract_keystrokes(input)
             assert len(output) != len(phrase)
 
-    def test_x(self):
+    def test_no_overlap(self):
         pass
 
 
 class TestCollectKeystrokeData:
-    base_dir = 'datasets/collection-tests/'
+    fpb = 'datasets/collection-tests/'
     keys = ['a', 'b', 'c', 'd', 'e', 'f']
 
     def test_standard_collection(self):
-        c = collect_keystroke_data(base_dir=self.base_dir,
+        c = collect_keystroke_data(filepath_base=self.fpb,
                                    keys=self.keys)
         expected_len = {'a': 5, 'b': 8, 'c': 10, 'd': 3, 'e': 8, 'f': 2}
         for letter in expected_len:
@@ -98,7 +94,7 @@ class TestCollectKeystrokeData:
             assert actual_len == expected_len[letter]
 
     def test_sound_digests_are_unique(self):
-        collection = collect_keystroke_data(base_dir=self.base_dir,
+        collection = collect_keystroke_data(filepath_base=self.fpb,
                                             keys=self.keys)
         used_digests = set()
         for data in collection:
@@ -112,10 +108,10 @@ class TestCollectKeystrokeData:
             'd-3x.wav': {2},
             'e-8x.wav': {6, 7},
         }
-        no_ignore = collect_keystroke_data(base_dir=self.base_dir,
+        no_ignore = collect_keystroke_data(filepath_base=self.fpb,
                                            keys=self.keys)
-        with_ignore = collect_keystroke_data(base_dir=self.base_dir,
+        with_ignore = collect_keystroke_data(filepath_base=self.fpb,
                                              keys=self.keys,
                                              ignore=ignore)
-        num_ignore = sum([len([val for val in ignore[key]]) for key in ignore])
+        num_ignore = sum([len([v for v in ignore[key]]) for key in ignore])
         assert len(no_ignore) - len(with_ignore) == num_ignore


### PR DESCRIPTION
## Objectives
The wav_read() function currently accepts a "filename" and "base_dir".
In practice, it's simpler to just accept a single filepath as an argument, and handle filepath
changes externally depending on the circumstance.

This pull request refactors wav_read() and all of its occurrences in the dataman package to 
reflect this desired change. Tests are updated to reflect the intended behavior.