### PR TITLE
Add database operations tests

### DIFF
--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -23,7 +23,7 @@ def wav_read(filepath):
     """Return 1D NumPy array of wave-formatted audio data denoted by filename.
 
     Input should be a string containing the path to a wave-formatted audio file.
-    File should be uncompressed 16-bit."""
+    """
     sample_rate, data_2d = wav.read(filepath)
     data_1d = [val for val, _ in data_2d]
     return np.array(data_1d)
@@ -33,6 +33,7 @@ def wav_read(filepath):
 
 def silence_threshold(sound_data, n=5, factor=11):
     """Return the silence threshold of the sound data.
+
     The sound data should begin with n-seconds of silence.
     """
     sampling_rate = 44100
@@ -46,7 +47,7 @@ def silence_threshold(sound_data, n=5, factor=11):
 
 
 def remove_random_noise(sound_data, threshold=None):
-    """Return a copy of sound_data where random noise is replaced with 0s.
+    """Return a copy of sound_data where random noise is replaced with 0's.
 
     The original sound_data is not mutated.
     """
@@ -196,8 +197,18 @@ class Keystroke(Base):
         return f'<Keystroke(key={self.key_type}, digest={self.sound_digest})>'
 
 
+class KeystrokeTest(Base):
+    """Schema for testing."""
+    __tablename__ = 'SampleKeystroke'
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    key_type = db.Column(db.String(32), nullable=False)
+    sound_digest = db.Column(db.BigInteger, nullable=False, unique=True)
+    sound_data = db.Column(postgresql.ARRAY(db.Integer))
+
+
 def connect_to_database(url=os.environ['TEST_DATABASE_URL']):
-    """Connect to database and return engine, connection, metadata."""
+    """Connect to database and return corresponding engine instance."""
     engine = db.create_engine(url)
     connection = engine.connect()
     return engine
@@ -216,7 +227,7 @@ def drop_keystroke_table():
 
 
 def store_keystroke_data(collected_data, database_url):
-    """Store collected data in database and return result proxy.
+    """Store collected data in database.
 
     input format  -- output of collect_keystroke_data()
     """

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -215,7 +215,7 @@ def connect_to_database(url=os.environ['TEST_DATABASE_URL']):
 
 
 def create_keystroke_table(url=os.environ['TEST_DATABASE_URL']):
-    """Create keystroke table in database."""
+    """Create keystroke table and test table in database."""
     engine = connect_to_database(url)
     Base.metadata.create_all(engine)
 
@@ -224,6 +224,12 @@ def drop_keystroke_table(url=os.environ['TEST_DATABASE_URL']):
     """Drop keystroke table in database."""
     engine = connect_to_database(url)
     Keystroke.__table__.drop(engine)
+
+
+def drop_keystroke_test_table(url):
+    """Drop test keystroke table in database. For testing."""
+    engine = connect_to_database(url)
+    KeystrokeTest.__table__.drop(engine)
 
 
 def store_keystroke_data(data, url=os.environ['TEST_DATABASE_URL']):

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -226,12 +226,12 @@ def drop_keystroke_table():
     Keystroke.__table__.drop(engine)
 
 
-def store_keystroke_data(collected_data, database_url):
+def store_keystroke_data(collected_data):
     """Store collected data in database.
 
     input format  -- output of collect_keystroke_data()
     """
-    engine = connect_to_database(database_url)
+    engine = connect_to_database()
     Session = orm.sessionmaker(bind=engine)
     session = Session()
     try:
@@ -250,7 +250,7 @@ def store_keystroke_data(collected_data, database_url):
 
 # Data retrieval
 
-def load_keystroke_data(database_url):
+def load_keystroke_data():
     """Retrieve data from database, do relevant formatting, and return it.
 
     Return as a tuple of tuples of the form: (x, y)
@@ -259,7 +259,7 @@ def load_keystroke_data(database_url):
     This data will be passed to tf.keras.model.fit().
     For details, view documentation at: https://keras.io/models/model/#fit
     """
-    engine = connect_to_database(database_url)
+    engine = connect_to_database()
     Session = orm.sessionmaker(bind=engine)
     session = Session()
     keystrokes = session.query(Keystroke).all()

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -226,19 +226,19 @@ def drop_keystroke_table():
     Keystroke.__table__.drop(engine)
 
 
-def store_keystroke_data(collected_data):
+def store_keystroke_data(data, url=os.environ['TEST_DATABASE_URL']):
     """Store collected data in database.
 
     input format  -- output of collect_keystroke_data()
     """
-    engine = connect_to_database()
+    engine = connect_to_database(url)
     Session = orm.sessionmaker(bind=engine)
     session = Session()
     try:
-        for data in collected_data:
-            entry = Keystroke(key_type=data['key_type'],
-                              sound_digest=data['sound_digest'],
-                              sound_data=data['sound_data'])
+        for keystroke in data:
+            entry = Keystroke(key_type=keystroke['key_type'],
+                              sound_digest=keystroke['sound_digest'],
+                              sound_data=keystroke['sound_data'])
             session.add(entry)
         session.commit()
     except:
@@ -250,7 +250,7 @@ def store_keystroke_data(collected_data):
 
 # Data retrieval
 
-def load_keystroke_data():
+def load_keystroke_data(url=os.environ['TEST_DATABASE_URL']):
     """Retrieve data from database, do relevant formatting, and return it.
 
     Return as a tuple of tuples of the form: (x, y)
@@ -259,7 +259,7 @@ def load_keystroke_data():
     This data will be passed to tf.keras.model.fit().
     For details, view documentation at: https://keras.io/models/model/#fit
     """
-    engine = connect_to_database()
+    engine = connect_to_database(url)
     Session = orm.sessionmaker(bind=engine)
     session = Session()
     keystrokes = session.query(Keystroke).all()

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -199,7 +199,7 @@ class Keystroke(Base):
 
 class KeystrokeTest(Base):
     """Schema for testing."""
-    __tablename__ = 'SampleKeystroke'
+    __tablename__ = 'test_keystrokes'
 
     id = db.Column(db.BigInteger, primary_key=True)
     key_type = db.Column(db.String(32), nullable=False)

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -254,6 +254,25 @@ def store_keystroke_data(data, url=os.environ['TEST_DATABASE_URL']):
         session.close()
 
 
+def store_keystroke_test_data(data, url):
+    """Store collected data in database. For testing."""
+    engine = connect_to_database(url)
+    Session = orm.sessionmaker(bind=engine)
+    session = Session()
+    try:
+        for keystroke in data:
+            entry = KeystrokeTest(key_type=keystroke['key_type'],
+                                  sound_digest=keystroke['sound_digest'],
+                                  sound_data=keystroke['sound_data'])
+            session.add(entry)
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
 # Data retrieval
 
 def load_keystroke_data(url=os.environ['TEST_DATABASE_URL']):

--- a/custom-packages/dataman/audio_processing.py
+++ b/custom-packages/dataman/audio_processing.py
@@ -214,15 +214,15 @@ def connect_to_database(url=os.environ['TEST_DATABASE_URL']):
     return engine
 
 
-def create_keystroke_table():
+def create_keystroke_table(url=os.environ['TEST_DATABASE_URL']):
     """Create keystroke table in database."""
-    engine = connect_to_database()
+    engine = connect_to_database(url)
     Base.metadata.create_all(engine)
 
 
-def drop_keystroke_table():
+def drop_keystroke_table(url=os.environ['TEST_DATABASE_URL']):
     """Drop keystroke table in database."""
-    engine = connect_to_database()
+    engine = connect_to_database(url)
     Keystroke.__table__.drop(engine)
 
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -133,7 +133,7 @@ class TestDatabaseOperations:
 
         # Assert that table does not exist by making a query
         session = Session()
-        with pytest.raises(Exception):
+        with pytest.raises(sqlalchemy.exc.ProgrammingError):
             session.query(KeystrokeTest)
         session.close()
 
@@ -155,7 +155,7 @@ class TestDatabaseOperations:
 
         # Assert that table is dropped by makign a query
         session = Session()
-        with pytest.raises(Exception)
+        with pytest.raises(sqlalchemy.exc.ProgrammingError):
             session.query(KeystrokeTest)
         session.close()
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -121,12 +121,14 @@ class TestCollectKeystrokeData:
 
 
 class TestDatabaseOperations:
+    url = 'postgresql+psycopg2://postgres@acoustickeyloggerresearch_db_1:5432'
+
     def test_connect_to_database(self):
-        engine = connect_to_database()
+        engine = connect_to_database(self.url)
         assert type(engine) == sqlalchemy.engine.base.Engine
 
     def test_create_keystroke_table(self):
-        engine = connect_to_database()
+        engine = connect_to_database(self.url)
         Session = orm.sessionmaker(bind=engine)
         session = Session()
         with pytest.raises(psycopg2.errors.UndefinedTable):
@@ -135,4 +137,15 @@ class TestDatabaseOperations:
         query = session.query(KeystrokeTest).all()
         assert type(query) == sqlalchemy.orm.query.Query
 
+    def test_drop_keystroke(self):
+        pass
+
+    def test_store_keystroke_data(self):
+        pass
+
+    def test_retrieve_keystroke_data(self):
+        pass
+
+    def test_load_keystroke_data(self):
+        pass
         

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -162,7 +162,22 @@ class TestDatabaseOperations:
         session.close()
 
     def test_store_keystroke_data(self):
-        pass
+        # Initialize database and data to be stored
+        fpb = 'datasets/collection-tests/'
+        keys = ['a', 'b', 'c', 'd', 'e', 'f']
+        c = collect_keystroke_data(filepath_base=fpb, keys=keys)
+        create_keystroke_table(self.url)
+
+        # Store data in database
+        store_keystroke_test_data(c, url=self.url)
+
+        # Assert that storage was succesful by making a query
+        engine = connect_to_database(self.url)
+        Session = orm.sessionmaker(bind=engine)
+        session = Session()
+        query = session.query(KeystrokeTest).all()
+        assert type(query) == list
+        assert len(query) == 36
 
     def test_retrieve_keystroke_data(self):
         pass

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -133,7 +133,8 @@ class TestDatabaseOperations:
 
         # Assert that table does not exist by making a query
         session = Session()
-        with pytest.raises(sqlalchemy.exc.InternalError):
+        with pytest.raises((sqlalchemy.exc.ProgrammingError,
+                            sqlalchemy.exc.InternalError)):
             session.query(KeystrokeTest).all()
         session.close()
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -131,7 +131,7 @@ class TestDatabaseOperations:
         engine = connect_to_database(self.url)
         Session = orm.sessionmaker(bind=engine)
         session = Session()
-        with pytest.raises(psycopg2.errors.UndefinedTable):
+        with pytest.raises(psycopg2.ProgrammingError):
             session.query(KeystrokeTest).all()
         create_keystroke_table()
         query = session.query(KeystrokeTest).all()

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -133,17 +133,18 @@ class TestDatabaseOperations:
 
         # Assert that table does not exist by making a query
         session = Session()
-        with pytest.raises(sqlalchemy.exc.ProgrammingError):
-            session.query(KeystrokeTest)
+        with pytest.raises(sqlalchemy.exc.InternalError):
+            session.query(KeystrokeTest).all()
         session.close()
 
         create_keystroke_table(self.url)
 
         # Assert that table exists by making a query
         session = Session()
-        query = session.query(KeystrokeTest)
+        query = session.query(KeystrokeTest).all()
         session.close()
         assert type(query) == sqlalchemy.orm.query.Query
+        assert query == []
 
     def test_drop_keystroke_table(self):
         engine = connect_to_database(self.url)
@@ -151,12 +152,12 @@ class TestDatabaseOperations:
 
         # Create and drop table
         create_keystroke_table(self.url)
-        drop_keystroke_table()
+        drop_keystroke_test_table(self.url)
 
-        # Assert that table is dropped by makign a query
+        # Assert that table is dropped by making a query
         session = Session()
-        with pytest.raises(sqlalchemy.exc.ProgrammingError):
-            session.query(KeystrokeTest)
+        with pytest.raises(sqlalchemy.exc.InternalError):
+            session.query(KeystrokeTest).all()
         session.close()
 
     def test_store_keystroke_data(self):

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -130,16 +130,34 @@ class TestDatabaseOperations:
     def test_create_keystroke_table(self):
         engine = connect_to_database(self.url)
         Session = orm.sessionmaker(bind=engine)
+
+        # Assert that table does not exist by making a query
         session = Session()
         with pytest.raises(Exception):
             session.query(KeystrokeTest)
+        session.close()
+
         create_keystroke_table(self.url)
+
+        # Assert that table exists by making a query
         session = Session()
         query = session.query(KeystrokeTest)
+        session.close()
         assert type(query) == sqlalchemy.orm.query.Query
 
-    def test_drop_keystroke(self):
-        pass
+    def test_drop_keystroke_table(self):
+        engine = connect_to_database(self.url)
+        Session = orm.sessionmaker(bind=engine)
+
+        # Create and drop table
+        create_keystroke_table(self.url)
+        drop_keystroke_table()
+
+        # Assert that table is dropped by makign a query
+        session = Session()
+        with pytest.raises(Exception)
+            session.query(KeystrokeTest)
+        session.close()
 
     def test_store_keystroke_data(self):
         pass

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -144,7 +144,6 @@ class TestDatabaseOperations:
         session = Session()
         query = session.query(KeystrokeTest).all()
         session.close()
-        assert type(query) == sqlalchemy.orm.query.Query
         assert query == []
 
     def test_drop_keystroke_table(self):
@@ -157,7 +156,8 @@ class TestDatabaseOperations:
 
         # Assert that table is dropped by making a query
         session = Session()
-        with pytest.raises(sqlalchemy.exc.InternalError):
+        with pytest.raises((sqlalchemy.exc.ProgrammingError,
+                            sqlalchemy.exc.InternalError)):
             session.query(KeystrokeTest).all()
         session.close()
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -135,5 +135,4 @@ class TestDatabaseOperations:
         query = session.query(KeystrokeTest).all()
         assert type(query) == sqlalchemy.orm.query.Query
 
-    def test_drop_keystroke
         

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -132,10 +132,10 @@ class TestDatabaseOperations:
         Session = orm.sessionmaker(bind=engine)
         session = Session()
         with pytest.raises(Exception):
-            session.query(KeystrokeTest).all()
+            session.query(KeystrokeTest)
         create_keystroke_table(self.url)
         session = Session()
-        query = session.query(KeystrokeTest).all()
+        query = session.query(KeystrokeTest)
         assert type(query) == sqlalchemy.orm.query.Query
 
     def test_drop_keystroke(self):

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -134,6 +134,7 @@ class TestDatabaseOperations:
         with pytest.raises(Exception):
             session.query(KeystrokeTest).all()
         create_keystroke_table(self.url)
+        session = Session()
         query = session.query(KeystrokeTest).all()
         assert type(query) == sqlalchemy.orm.query.Query
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -133,7 +133,7 @@ class TestDatabaseOperations:
         session = Session()
         with pytest.raises(Exception):
             session.query(KeystrokeTest).all()
-        create_keystroke_table()
+        create_keystroke_table(self.url)
         query = session.query(KeystrokeTest).all()
         assert type(query) == sqlalchemy.orm.query.Query
 

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -131,7 +131,7 @@ class TestDatabaseOperations:
         engine = connect_to_database(self.url)
         Session = orm.sessionmaker(bind=engine)
         session = Session()
-        with pytest.raises(psycopg2.ProgrammingError):
+        with pytest.raises(Exception):
             session.query(KeystrokeTest).all()
         create_keystroke_table()
         query = session.query(KeystrokeTest).all()

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -6,6 +6,9 @@ Tests for "audio_processing.py" in "database_management" package.
 import pytest
 import numpy as np
 import numpy.random as rand
+import sqlalchemy
+import sqlalchemy.orm as orm
+import psycopg2
 
 from dataman.audio_processing import *
 
@@ -115,3 +118,21 @@ class TestCollectKeystrokeData:
                                              ignore=ignore)
         num_ignore = sum([len([v for v in ignore[key]]) for key in ignore])
         assert len(no_ignore) - len(with_ignore) == num_ignore
+
+
+class TestDatabaseOperations:
+    def test_connect_to_database(self):
+        engine = connect_to_database()
+        assert type(engine) == sqlalchemy.engine.base.Engine
+
+    def test_create_keystroke_table(self):
+        engine = connect_to_database()
+        Session = orm.sessionmaker(bind=engine)
+        session = Session()
+        with pytest.raises(psycopg2.errors.UndefinedTable):
+            session.query(KeystrokeTest)
+        create_keystroke_table()
+        query = session.query(KeystrokeTest)
+        assert type(query) == sqlalchemy.orm.query.Query
+
+        

--- a/tests/test_dataman/test_audio_processing.py
+++ b/tests/test_dataman/test_audio_processing.py
@@ -130,9 +130,10 @@ class TestDatabaseOperations:
         Session = orm.sessionmaker(bind=engine)
         session = Session()
         with pytest.raises(psycopg2.errors.UndefinedTable):
-            session.query(KeystrokeTest)
+            session.query(KeystrokeTest).all()
         create_keystroke_table()
-        query = session.query(KeystrokeTest)
+        query = session.query(KeystrokeTest).all()
         assert type(query) == sqlalchemy.orm.query.Query
 
+    def test_drop_keystroke
         


### PR DESCRIPTION
## Overview
Create unit tests for database operations.
Objective is to regularly ensure that data manipulation is possible for any collaborators of this project.

## Comments
Some database operations tests (as well as existing silence threshold tests) catches the general raised "Exception", which is bad practice. Should diagnose and specify what type of exceptions should be raised and excepted in each case. Skipping this process now because these tests are completely acceptable for the current state of the project.